### PR TITLE
Update Lab 6: Remove formatted_response from prebuilt element and add custom React agent subsection

### DIFF
--- a/langgraph_agents/6.prebuilt_react.ipynb
+++ b/langgraph_agents/6.prebuilt_react.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "from langchain_aws import ChatBedrock\n",
-    "llm = ChatBedrock(model=model_id)"
+    "llm = ChatBedrock(max_tokens=8192, model=model_id)"
    ]
   },
   {
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,8 +89,6 @@
     "    \"\"\"\n",
     "    bedrock_agent = boto3.client('bedrock-agent-runtime', region_name = aws_region)\n",
     "    print(\"QUERYING KB\")\n",
-    "\n",
-    "\n",
     "    response = bedrock_agent.retrieve_and_generate(\n",
     "        input={\n",
     "            \"text\": query  # Your query text goes here\n",
@@ -115,48 +113,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "@tool\n",
-    "def blogger_tool(context):\n",
+    "def blogger_tool(context, language):\n",
     "    \"\"\"Ue this tool to write a well formatted blog with a blog title\n",
     "    \n",
     "    Args:\n",
     "        context: The context for the blog\n",
+    "        language: Language to write the blog; choose 'English' as default if not mentioned by user.\n",
     "    \"\"\"\n",
     "    print(\"WRITING BLOG\")\n",
-    "    prompt = f\"\"\" Your job is to create a blog title and a one paragraph blog from this content: {context}\"\"\"\n",
+    "    prompt = f\"\"\" Your job is to create a blog title and a detailed multi-paragraph blog with sections from this content: {context} \\n\\n The Blog has to be written in Language : {language}\"\"\"\n",
     "\n",
     "    final_answer = llm.invoke(prompt)           \n",
-    "    return final_answer"
+    "    return final_answer.content"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "@tool\n",
-    "def translate_tool(context, language):\n",
-    "    \"\"\"Ue this tool to translate the content from english to any other language\n",
+    "def translate_tool(blog_content, language):\n",
+    "    \"\"\"Use this tool to translate the blog_content from english to any other language. The context here is the complete blog written in a different language to the one user asked for.\n",
     "    \n",
     "    Args:\n",
-    "        context: The context to be translated\n",
+    "        blog_content: The blog to be translated\n",
     "        language: The language to translate to\n",
     "    \"\"\"\n",
     "    print(\"BLOG TRANSLATION\")\n",
-    "    prompt = f\"\"\" Your job is to translate the context in {context} from english to {language} \"\"\"\n",
+    "    prompt = f\"\"\" Your job is to translate the blog:\\n {blog_content}. \\n\\n Translate to {language} from source language. Make sure to be comprehensive when translating; cover complete context.\"\"\"\n",
     "\n",
     "    final_answer = llm.invoke(prompt)           \n",
-    "    return final_answer"
+    "    return final_answer.content"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,36 +164,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
-    "##### Response Formatters"
+    "## Build the agent (Prebuilt Langgraph)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pydantic import BaseModel, Field\n",
-    "\n",
-    "class FormattedResponse(BaseModel):\n",
-    "    \"\"\"Respond to the user in this format.\"\"\"\n",
-    "    Blog_Title: str = Field(description=\"title of the blog\")\n",
-    "    Blog_Content: str = Field(description=\"content of the blog\")\n",
-    "    Blog_language: str = Field(description=\"language of the blog\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "##### Build the agent"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,27 +181,15 @@
     "\n",
     "graph = create_react_agent(\n",
     "    llm, tools=tools, \n",
-    "    checkpointer=memory,\n",
-    "    response_format=FormattedResponse,\n",
+    "    checkpointer=memory\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAFNCAIAAACBvTPSAAAAAXNSR0IArs4c6QAAIABJREFUeJzt3XdcE+cfB/AnexMIeyMuZFTcFmytttq6q2Lr3rWKe6FWrbjqFosTq5W6FYt14KqjzroFF9uB7JlNdn5/nL8ULQLVXO4Svu+XL1+Zl29yyYfnnrt7HorRaEQAAIA/KtEFAADqC4gbAICFQNwAACwE4gYAYCEQNwAAC4G4AQBYCJ3oAqxMaZ5KIdUrpXqN2qCuNBBdTu1oNAqNQeEKaDw7ur0Lg2cHaxwQhgLH3dTFy1TFs8eK548VXo05KoWBa0dzcGbqdVbw0dHoSCnTK2V6pVSv0xmMRuQfzGvYnO/gwiS6NFDvQNzUIidNeeNEqZMXy82H3SCYxxNad+ug6KXq2WOFuETDYFHDezlx+DSiKwL1CMRNTc7tK6yU6cN6OTl7soiuxcxSb0mvnyht2dm+ZWcR0bWA+gLipnrlhZoDq3P6TfZ0b8AhuhYcpVwV52ZU9hjjTnQhoF6AuKmGXKw7ti1vUJQPlUohuhbcPXskv3mqfPAcH6ILAbYP4uZthS9UFw8VDZ7jS3QhlpOfrTx/oHj4Aj+iCwE2Do67eYNWY/hjS169yhqEkEdDbnhvp1O/FhBdCLBx0Lp5Q9LOgk/6OtmJGEQXQoCUq2KDztiikwPRhQCbBa2bfzy8JuYL6fUzaxBCzT+xv3OuQl2pJ7oQYLMgbv5x40RZWC9HoqsgUlgvxxsnyoiuAtgsiJvXki9XtOsuYrDq9QcSHCaslOslpRqiCwG2qV7/uqpKvyP3bGjLh9jUkUBEf/5YSXQVwDZB3CDsQBulXOfixbbki2ZnZ/fs2fM9nnj48OHo6GgcKkIIIf9g/vPHCpwWDuo5iBuEEMpJUwS0tbPwi6amplr4iXXh2Yij0xnUSugwBuYHcYMQQmWFGg4Xr5MVCwsL586d26VLl7CwsIiIiMTERIRQXFxcdHR0YWFh69at9+/fjxB6+vRpZGTk559/3qFDh+HDh9+6dQt7+uHDh7t06XL58uUuXbps2LBh3LhxJ06cOHnyZOvWrdPT0/Eo2KBDknItHksG9Zx1n99sLkqp3tUHry2pxYsXazSaDRs2CIXCmzdvrly50sPDY8SIETKZ7NKlS/v27eNwOGq1evLkySEhIVu2bGEwGImJiTNnzkxMTHRxcWEwGJWVlQcPHoyOjvbz8xMKhePHj/fx8YmKihIIBHgUzLWjKaXQugHmB3GDEEIKiQ6/kSWysrK+/fbboKAghFBERERAQIC7uzubzWaxWBQKxd7eHiGk0+ni4uKcnJywqxMmTDh48GBKSkqXLl0oFIpKpRo8eHB4eDi2QDqdzmQysUfigSekKyQ6nBYO6jOIG4QQojEoNNwGfvn000/j4+NlMll4eHiLFi2Cg4P//Rg6na7ValevXp2RkSGTybBDvSUSiekBISEheNX3LwwWBQ41B3iAuEEIISaLKpfgtfkwb968Ro0anTp1at++fTweLyIiYsKECXT6G598Tk7O+PHj27Rps3TpUmdnZ4PB0L1796oP4PP5OJX3b9IyHRwTAPAAcYMQQlw7ulKK1+YDnU4fNGjQoEGDysrKkpKStmzZ4uDgMHTo0KqPOXfunF6vX758OYvFwnqXcSqmLpRSHReGNAY4gD1TCCEkcmNoNbiMcy6Xy0+fPq3T6RBCjo6Ow4cPDwkJycrKeuthGo0G683Brp46darmxeJ6Yi1HQOPbQ9wA84O4QQghr0bc1NsyPJZMoVBWrVq1bNmy9PT0vLy8M2fOpKamtmrVCiEkEAhKS0sfPHhQUFAQHBwsFouPHz9eWlqakJDw5MkTBweHjIwMuVz+72UKBIL09PT09HSxWGz2gotfqRQSPd/Kh2QG5ETD7/hUK8Lh01KuSHybcdk8M/cYM5nM1q1bX7x4MT4+/uDBg5mZmUOHDh0wYABCyM3N7dq1awcOHOBwOP3796+srNyzZ8/BgweZTObChQv1en1CQoJEInFycrpy5crYsWOp1Nd/G4RCYVJSUmJiYosWLby9vc1b8OMbEgdXpmcj6LsB5gfj3bx251w5144W1F5IdCEEO7u7sGVne2fLns8B6gnYmHqteUf7a0dLia6CYM8eyXVaI2QNwAlsor/GZFGbd7S/c668TdfqJ0I5efLk2rVrq71Lo9EwmdXPErd48eKOHTuatdJ/TJs2LTk5+b+WtHv3bh+f6gdCv3GirMdYmJUB4AU2pt6QuCm3b6QnpboJGLRarUqlqvZZKpWKza6+RcDhcN46xMaMlEqlXl/94UI1lMTj8UzdQFVlPpCV5KnDejqZu0wAXoO4eUNpvvrPvUWDourdLChl+eqze4sG1783DiwJ+m7e4OTBatnZ4eSOfKILsbQDa15B1gC8QeumGnnPKpMvievJ3JKSUm3ChlcjF/nRGfC3B+AL4qZ6mQ9kt86UR0z1ZHNtuTf9Zari8u8lg6J8GEzIGoA7iJt3qijSXEoodvFih/VypNJsbfbeohzVjRNlIldGxwgXomsB9QXETS0e/FVx40RZuy9FHo04Hv5Wf6ytVmN4/lhRlKMqeKYK6+Xo1ZhLdEWgHoG4qZOUq+KsB/LyQk3Qx3ZGI+Jhs99ZQ4uHRqUo5TqFVKeQ6FUK/fPHigbBvCYtBQ2CeUSXBuodiJv/QKXUv8pQysp1ColOr0dmH/IuOzvb0dHRvMP0MdlUCgXx7Og8IU3kyvRqAs0ZQBiIGxKZNWtWz549P/vsM6ILAQAXsD8CAGAhEDcAAAuBuCERZ2dn/E6wAoBwEDckUlJSgg0zCoBNgrghETabTaFYw951AN4LxA2JqFQq2FEIbBjEDYnY2dnR8JteDwCiQdyQiFQqfddwWQDYAIgbEnFzc2MwGERXAQBeIG5IpLCwUKvVEl0FAHiBuAEAWAjEDYlwudxqBy0HwDbAl5tElEqlwYDLVOUAkAHEDYm8a0oWAGwDfLlJRKFQQOsG2DCIGwCAhUDckIijoyOcEQ5sGMQNiZSVlcEZ4cCGQdwAACwE4oZEXFxcYGMK2DCIGxIpLi6GjSlgwyBuAAAWAnFDIq6urnBGOLBhEDckUlRUBGeEAxsGcQMAsBCIGxKBiV+AbYO4IRGY+AXYNogbAICFQNyQCMwzBWwbxA2JwDxTwLZB3JAInBEObBvEDYnAGeHAtkHcAAAsBOKGRAQCAYxVDGwYfLlJRCaTwVjFwIZB3JAInKIJbBvEDYnAKZrAtkHckAi0boBtg7ghEWjdANsGcUMiQqGQRqMRXQUAeKHAUfOE69q1K4PBoFKpYrGYw+FglxkMRmJiItGlAWBOcMg88ezt7Z89e4ZdrqysxC4MHDiQ0KIAMD/YmCLegAED2Gx21Vs8PDwGDRpEXEUA4ALihnh9+/b18PAwXTUajZ988omnpyehRQFgfhA3xKPT6RERESwWC7vq6ek5dOhQoosCwPwgbkihX79+3t7epqaNu7s70RUBYH4QN6RAp9P79+/PZDI9PT2HDRtGdDkA4AL2TP03KqW+NF+jUZn/RMqWAd2a+T4IDAxUlgqelSrMu3AKQnwHusiVSaPD4KSAMHDcTV0ZDcaze4py0pReTbg6jZV9aEwOtbxAjRAKaCNo2dmB6HJAPQVxUycateH32NyWnR09GvGIruWD3EwqthPR230lIroQUB9B302dHNmQG97H1dqzBiHUvoeLrEJ/70IF0YWA+gjipnZPb0m8mnAdXFlEF2Ie7bo7Z6fI1ZV6ogsB9Q7ETe1KXmnYfJvqUzcaUUUxnHoOLA3ipnbqSr2diEl0Febk6M6WVcCUD8DSIG5qp6k0GPU21aGuVukRjIkMLA7iBgBgIRA3AAALgbgBAFgIxA0AwEIgbgAAFgJxAwCwEIgbAICFQNwAACwE4gYAYCEQNwAAC4G4AQBYCMQNAMBCIG6s3tf9vigozCe6CgBqB3Fj3YqKCiUSMdFVAFAnEDe4SEt/Omt2ZJ++n3fr0WFC5PC7926Z7nr0KPm7cYO7fvXxyNEDbt2+MXnqmA0/r8TuyshMi5ozqU/fz3v0+nThj7MKCwuw248dP/J1vy9SUx9PmDiiZ++Og4f0PnX6GELoQfLdgYN7IoQGD+m9ZWsMQe8VgLqCuDE/tVo9Z+5kBpO5ds2WrZt3BwZ9tPDHmSUlxdhdC36cyeXxNm+KnzZl7o4dmwoK8igUCtZOmTHzewqVGrMubt3abVKZZObsCRqNBpuFSqGQ7967Y/Gi1SeO/dW1a4+YDStKSopDgkN/XLgCIRS3be/oUROIft8A1ALixvxoNFrMuri5UdGNGzX18/MfPXKCSqV6/CQFIfT3zatSqWT61HmNGzUNDW01ZXJUWVkp9qzjJ45QKJQF85f7+zcKaBr4w9ylBQV5l69cwO7V6XSDB450cXGlUCjdvuqj0+myszPodDqXy0MICQR2bDab0DcNQO1saghekqDT6VqdNnbj6qzsDLlchk2tI5VKEEI5OS/4PL6fnz/2yJCQUKHQHrucmvo4oGmQgC/Arrq6urm7e2ZlpXf5oht2i79/Y+yCQGCHEJLJZUS8OQDeH8SN+eXm5sycNb5FaJsf5i11cnQ2GAzfDOyO3SWVSri8N2aPsbMTYhcUCnlmVnrXrz423aXVasvKS01XWaw3p4KACcKAtYG4Mb+Ll87p9foF85djAVFUVGi6i8ViqVSqqg/GWj0IIR6PHxISOnP6/Kr3cjhcS1UNAO6g78b8tFoNi8U2NUb+PH/KdJenp7dUKsnLz8WuPnqUbNqN3axZcF7eKw8PLx8fP+wfhUJxdHSqyyvCVKjAKkDcmF+zgGCJRHz6zPGystI/jiWkpT+xt3fIzs6Qy+Xt23VgsVibNq/NyXnx6FHy1rgNpkDp1bN/ZaVy1erozKz03Nyc3Xt2jBrzTVrak5pfy05ghxC6efOaKcIAIC2IG/MLC/v022+GxW2PHTk64vHj5LlRi/v0jjh77uSOnZtEIsdFC1e+evVy7LhBm7esixw/ncfjM5kshJCbm/v6dXHl5WVTpo4ZHzns9p0by5auDwwMqfm1mjRp1rZt2NZtMQcP/map9wfAe6JAO7xWJ7fnNwwVejU1zwThEqmE/f9NLY1G06dv53HfTen79TdmWXgdXfm9sEkov3FLviVfFADoKrYouVw+dFifli3aDh/2HYVCOZSwh0qlfvpJZ6LrAsASIG4sis/nr1q56ZdfNk6ZNoZKoTZs1GTNqs117A8GwNpB3FhaYLPgmPVxRFcBAAGgqxgAYCEQNwAAC4G4AQBYCMQNAMBCIG4AABYCcVMvGY1vnSkKgAVA3NRTq1atSkhIILoKUL9A3NQiJSXlVa7Nnf1IoSxatMjf3x8hlJSUdOXKFaILAvUCxM07KZVKhNDPP//s4OBAdC24aNWqFUKoefPmR48evXr1KtHlANsHcVONzMzMkSNHlpeXI4R+/fVXPs88J2eSk5eXV0xMTOvWrRFCgwcP3rBhA9EVAZsFcfOGtLQ0hND9+/dnzpzp5eWF3ShwYCCKTZ03z+HR6EzKG7dwOAihPXv2ODo6IoSKiooePnxIXIHANkHcvFZRUfH111+npqYihL799tuQkH8GmuHY0Upy1YRWZ2Y56QpHd+a/b6fRaMOGDUMI8Xi8mJiYLVu2EFEdsFkw3g06depU9+7dc3NzjUajt7f3vx9Q9FJ1509xxwFuRFRnfrIKzd2zpb2/96j1kbm5uV5eXmvWrHFxcRk+fDg2HxYA762+t26ioqLy8vKwLoxqswYh5OrLdm/Auv5HkcWrw8XFA4Wf9nOuyyOxzcnIyEiJRJKeno4QKiwsrMPzAKhePW3d7Nq1i0qljhgxQqlUcrl1mu0g5arkZarSuynPyZPNYFpZTFMoSFqulZVrbhwvGfGjr8CB8X7LGT9+vIuLy5IlS8xdIKgX6lfcGAwGKpWamJiYn58/fvx4Ov2/DfeTm6lMvS1TyvQVRRo8ylOrVDQ6/b9WVRdcOxqdTvVoyG7f3fEDF3Xr1q127dqlpKTk5ub26NHDTAWCeqEexc2OHTtOnz79+++/G41GEnZDpKenz54928fHZ9OmTUTXUjulUrly5UoXF5dJkyYRXQuwGrY/mp9KpZJIJK6urhwO5/fff0cIkTBrEEIJCQl5eXkajebq1auffPIJ0eXUgsvlLlmyBDsScsWKFSwWa8qUKXi0y4AtsbI+iP/q9u3bn3/+OfYzGDJkCNHlvFNmZua9e/coFEppaenu3buJLqeusG6vefPmubq6FhYWqlQqrEcZgGrZZtzodLqjR48ihJhM5vXr17FD18js4MGDOTk52OXs7GyrO6VgyJAhXl5edDp98eLFGzduJLocQFK2GTfh4eFMJhMhFBoaSnQttcvIyLh7965pE08qlf72m1XOUUen0/fv3//5558jhM6ePXvhwgWiKwLkYlNx89tvv2FnIdy6dcuKdprs3r07982Tzp89e3bt2jXiKvoggYGBCKE2bdqcPXv27NmzRJcDSMR24mb16tUSiSQgIIDoQv6zO3fumJo2BoMBISQWi3ft2kV0XR9EJBKtXr06PDwcITR37txDhw4RXREgntXvCD99+vTz588jIyM1Gg22AWW9ZsyY0adPn44dOxJdiJlJpdJt27YNHz7c2dmZRqMRXQ4gjHW3bp4+fXr9+vXhw4djvcJEl/OhnJyc2Gw20VWYn52dXVRUlKurq9FobN++/bFjx4iuCBDDKuMmNzd32rRpCKEGDRosW7aMz+cTXZF5pKamCgQCoqvAC4VCodPpV69e1el0prE+QL1iZXGDfVNjY2MHDx5sGqXFZmi1WldXV6KrwBeDwejfvz92uW3bttiIH6CesKa42bVr1/Hjx7Fe4bZt2xJdjpmVlZWVl5eT/xAhcwkICPj777+xvx+nTp0iuhxgCVYTN9euXVMoFP369SO6ELykpaVh+3HqDxqNhg1jJpVKv/zyS6LLAbgj+54psVi8fPnyNWvWqNVqFotFdDk4WrRoUZs2bXr27El0IcSQyWQCgeDevXtlZWVdu3YluhyAC7K3btavXx8REYEQsu2sQQiVl5fb3i7wusP6yIODgy9duvTnn38SXQ7ABUlbN/fv379y5Qq2+6k+OHr06JMnTxYsWEB0IaRQUVHh4OAQExMzaNAgNzcbGbMVkLR1I5VKt27dOnLkSKILsZzffvttxIgRRFdBFtjEXh07doyMjCS6FmBO5Grd3Llzh8fj+fv72+TRbu9y+vTpx48fz549m+hCSOrKlSsSiaRXr15EFwI+FIlaNw8fPty5c2fTpk3rVdbodLro6GjImhp06NDh3r17t27dIroQ8KFI0bopKSlxdnZ+/vx5gwYNiK7F0ubPn//ZZ5916dKF6ELITiKRCIXCPXv2YDNhAWtEfOsmOTl5ypQp2BkJRNdiaUePHuVwOJA1dSEUChFCbDYb+7YAa0R86+bAgQODBg0itgZCPHr0aN26dfHx8UQXYmWwtvD169fr21GRNoDI1s1PP/2EEKqfWaNUKiMjIyFr3oOzszN27tWwYcMI/2MJ/hPCWjerVq364osvWrVqRcirE659+/Z///03OeeEsBZPnz719PTU6XT150Qza0dY3GDzTxPy0sRSq9Xh4eE3btywgQF6yCA5OfnJkydknmYDmBCwMRUdHZ2fn18/s6aioqJTp053796FrDGX0NDQoqIisVhMdCGgdpZu3cTExHTp0iU4ONiSL0oSN27c2L9/v1VMkml1FAoFh8OhUonf0wpqQPyeqXri119/ffDgAczBhJ9Lly4lJSWtXbuW6ELAO1kubtLS0q5fvz5mzBjLvBypREVF+fr6Tpw4kehCbFxhYWFBQUGLFi2ILgRUz3Jx89lnn504ccKGx+Kt1suXL2NjY7t3745N9gbwplKp9Ho9j8cjuhBQDQvFjUwmo9PpNja0cK32799/5MiRjRs3enp6El1LPTJr1qwePXp06tSJ6ELA2yzRtWY0GhkMRr3KGp1OFxkZWVBQkJiYCFljYWvXri0uLtZoNEQXAt5midZNfHy8TCabPHky3i9EEtevX58xY0ZsbGy7du2IrgUAEqFb4DUKCwvrSQ+xwWCYP3++SCSC0RIIt2LFip49e2JDrwOSsMTG1Ny5c7HzXGxbUlJSu3btOnXqBIPXkEG3bt02bNhAdBXgDbhvTBUVFZWXlzdr1gzXVyGWVCqdP3++g4PDkiVLiK4F/EOtVtPpdJiVnDxw35g6f/58UVGRDcfNgQMHtm/fvnz58rCwMKJrAW+w+dk7rA7uG1MikchWT/t+9OjRN998U1BQcOnSJcgaEkpLS4NTN0kF99ZNt27d8H4JyzMajUuXLn327NmKFSsaNmxIdDmgegEBARQKxWAwwLlUJIH7anjx4kV2djber2JJp0+fbtOmTfPmzePj4yFrSG7v3r2QNeSB+5p4/vz51q1b8X4Vy0hOTh48ePCzZ8/u3r3bp08fossBtZPL5TqdjugqwGu475kqKyvr378/n8+XyWQymez+/fu4vhxOxGLxqlWriouLo6KimjZtSnQ5oBYDBgyg0+kMBiMnJ8fBwYHNZjMYDCqVCqO1Eguvvptx48Y9fPjQ9IdFLpcjhFxcXO7fv9+yZUucXhQn27ZtS0hImDNnTteuXYmuBdRVZmYmdgH77hmNxt69exNdVH2H18bU9u3bvb2937qRxWJ99NFHOL0iHk6ePDlx4kQajXbhwgXIGisSFhb21jjQLi4uo0aNIq4igPDtu5k0aZKHh4fpqtFoDAwMpNMtcdrEh7t9+/bAgQPv3LmzcuXK7777juhywH8TERHh5+dnumo0GsPCwnx8fAgtCuC5I7xjx47p6en79u1TKBTYhGRWccpiTk7OunXrNBrN0qVLGzduTHQ54H14e3t//PHHz58/x666uLiMGDGC6KIAzsfdjBs3LjMz8/LlywaDwcHBgeTny8nl8g0bNrx69WrYsGEdOnQguhzwQQYMGHD58uW8vDyDwfDxxx9D04YMcN8R/tNPPzVs2NBgMAiFQjIfpbJ169YePXoEBQXFxcVB1tgAb2/vsLAwo9Ho6ek5cuRIossBqK6tG53WUCk3vO9LUKJmLPrpp5/atAiXVeB1BITRYLRzZLzfc48dO7Z69epRo0ZdvnzZ3HXVRKXQazUwLj2O+vYafPNaSocOHRwEHvh994DRaLQT1enXV8txN6m3pQ+vSsoLNRw+qU+rFTgwCp5XNgjmtexs796grsMGnjt37ueff+7Ro8fo0aPZbDbONf7j1pmy1FsyDp9WKddb7EUBwIm9MzM/W+n/Eb9NFwdHj5pOi60pbm6fKy/N14Z2FAnqFl3EMhqNkhLttWNFYT0cfZtxa37wrVu3YmNjfXx8pk6d6ubmZqkakdFoPPlLoYsP2yeQzxdawacKQF0Y9EZxiebK74Vdhri6+b7zL/c74+bWmXJpma59Txc8i8TF6V9z230lelfipKambt682WAwTJkyJSAgwMK1Hd+e79WE37iFnYVfFwDLOL4lp8tQFxfv6hOn+ripKNbcOFH2aYQ7/uWZn0atv3qk8OvItwckz83NjY2Nzc/Pnzp1aps2bSxfWFayPDdb1eoLJ8u/NACWIavQPjhf2mNs9dFRfVdxaZ7aaKRUexf5MVk0cYlWWq41dV9JpdLY2Ng7d+5MmTKFwPmeCl+qWBxSd4EB8IEEDoxXmUqN2sBkVbPXu/od4XKJ3vkdzSGr4N2UV1GsxS7Hxsb26dMnKCjo2LFjxM4tp1UbRG4wvhywcb6BvPICdbV3VR83WrVBq3rvPd/Ek4u1Rr0xPj6+devWQqHw0qVLffv2JboopBDrDDrY8w1snLRMh1D120bWcQbTf2U0GufNmxfWpfHdu3eJrgUA8Jqtxg368ccfm7WGTlkASMQ2x1WkUin1ao5gAKyCbcYNAICEIG4AABYCcQMAsBCIGwCAhUDcAAAsBOIGAGAhEDcAAAuBuAEAWAiJ4mZRdNTMWROIrgKA/+Dn2FWjxnxDdBVWw2xxc/SPwytXR5traYDMvu73RUFhPh5Ljl4858zZE2ZcIH6lgvdgtrjJyEg116IAmRUVFUokYpwWbt5vEa6lgvdgnlM0p80Yl5JyHyF09uzJ7XH7Gjdq+uhR8i87N2VkpFIolGYBwd99N7lZQBD24KRTfxxO2Jufn8vhcNu1DZswfrpI5PjWApNO/XHk9/0FBXksFrv5Ry0nTZzl4uJqllKty6NHybEbV7/Mee7h4TVh/PS9+3Y29G88bepchJBYXLFlW0xKyj2JROzv3/i7sZNahLZGCB07fmRX/LYVyzfEblrz6tULO4Fw6NAx3bv1wRaYkZm2Y8em9IxUnU7bskXbiZEz3dzcscbp7j2/zJqxYO36ZV279Jgwflpa+tMdOzZlZqVrNGo/X/8xYya2btXuQfLdGTPHI4QGD+kdHt5x2ZJ1Op1u776dFy+dKyoqcHZ2HRAxpE/viFrfV7Xrt9PnrRFCq1Yv3rxl3Yljf0UvnkOhUHx8/A4n7P1xwQoHkeOEyOFbt+wOaBqILWTosK/Dwz+bMH4aQig19fHWuA0ZGal2dsLOnb4cPWrCk6cP3yq1W48OI0d8/+03w7Cnr1m7NCsrPW7bXqwRNHTI6Dt3bz54cCfxyJ98Pv/CxbMJCXtf5jzncLidO305dsxEbPD80tKSNeuWJiff5fH4vXv1r+N6rPvyi4oKt8VtSE65p1Qq3Nw8IvoP7tWzH0Jo/sIZNCotKOijxKMHxeIKP1//6dN/wD4KjUaz89ctl/46V1FR7ujo9MXn3UaO+B6brrZv/y7DhowpKi68eOlsZaUyJKTFrBkLHB2daviJvet7ZRbmad0sW7K+SeOAzp26/pF43r9Bo1evXs6KinR2ctm8MX5T7C4Olztr9oTi4iKE0LlzSWvXLevapcevOw4tiV6TkZk274epbw1g+vDhg7XrlvXvN2j0PmhkAAAXVElEQVTnjkMrfvpZIhUvXjrXLHVaF7VaveDHmVweb/Om+GlT5u7YsamgIA+b+tpgMMyZO/nJk4dzoqLjtu4NaBo4d96UZ8+yEEJ0Ol2hkO/eu2PxotUnjv3VtWuPmA0rSkqKsa/yjJnfU6jUmHVx69Zuk8okM2dP0Gg0CCEGg6FSVSYePTgnKrpPnwFqtXrO3MkMJnPtmi1bN+8ODPpo4Y8zS0qKQ4JDf1y4AiEUt23vvDlLEELb4n4+dHjPkEGjdu44NCBiyKbNa5NO/VHz+3rX+j188BRCaPKk2Xv3HMNKevY8KyMzbeVPsYGBNU2IWFCYPysq0sPda/3abZMnzT5z9sTWbTH/LrUGdDr9xMlE/waNYtbFsdnsa9f+WrZ8fqtW7X7ZfiBq9qIrVy+si1mOPXLFyh9fvMhe8dPPMeviJBLxlasX67Iq67781WsWl5aV/LR8w687D/frO3DDzyvv3L2JEKLT6A8e3MnPz90dn3gk4axQaB+9OMpgMCCENvy88vSZ4+O/nxa/68iY0ROP/nEobnus6XUPHPrNz8//wL4Tv+44nJmZtmfvjhpWQQ3fK7MwT9zw+Xwanc5gMoVCexqNduz4EQ6HO2/ukoYNGzds2Hj+vGU6ne7suZMIoYQj+8LDOw4ZPMrb2zc0tNXkSbMzMtMeP06purTnL7JZLNZXX/by9PAKbBa8aOHKiZEzzVKndfn75lWpVDJ96rzGjZqGhraaMjmqrKwUu+vuvVsZmWmzZi5o2aKNr2+DSRNnubq6Jx49iN2r0+kGDxzp4uJKoVC6fdVHp9NlZ2cghI6fOEKhUBbMX+7v3yigaeAPc5cWFORdvnIBIUShUFQqVUT/we3bhXu4e9JotJh1cXOjohs3aurn5z965ASVSvX4SQqdTudyeQghgcCOx+PJ5fJjxxO+/WbYl1/29PL07tM74suuPfcfiK/5fb1r/drZCRFCXC5XaCdECBkRys/PnTtncfPmLYVC+xoWmJR0lMlkzZ61MDAw5JMOnSLHT9dqtW+VWnNJFAqFzWJ/P25KUNBHdDp9/8H45s1bfjd2kpend/t24d+NnXz+/Oni4qKSkuL7D+4MGjgS+9inTI7CXqJWdVw+QujZ86w2rT9uFhDk6eHVp3fEpthfG/q/njlab9BHTpjBYrEEfMHwYd8VFRUmp9yTSMTn/kwaPmxs505dPT28unzRrV/fgSeTErXa16NZ+vo06PZVbzqd7uLi2rZNWHr60xpWQc3fqw+Hy56pjMzUJo0DsOYc9gXy9vbNzs7Q6XTZzzIDm/3zl6pp00CEUFZ2RtWntwhtTaFQpkwbezLpaEFhvkjkGNgsGI86SS4n5wWfx/fz88euhoSEmn51qamPGQxGaPNW2FUqlfpRSIusrHTTc/3//x0VCOwQQjK5DHtWQNMgAV+A3eXq6ubu7ln1WaZGBJ1O1+q0sRtXjxgV0X/Al8NG9EUISaWStyrE1mnrVu1NtzRv3io/P1epVNbwvuq+fr29fbHoqVlGRmqTxgE02utxoLt27TFr5oJan/WWoKCPsAsGgyEjI7Xqm8I+52fPMl/mPEcIBfy/W4BCoZgum2X5CKGwjz89cDB+y9aYe/dva7XaZs2CTV0Nvj4NWKzXg8/6+TVECOXlvcp+lqnX69/6TalUqtzcHOyq6ZuAfRmkMmkNq6DW79UHwmV4LaVS4Sh6Y2grLpenVCoqVZVGo7HqHwQuh4sQqqx849vp4+O3KXbXgUO/bf9lo2z98mbNgidNnFUPE0cqlXDf/LNs9//fnlKp0Gq1X3YLM92l1+urdoGZvpevGY0IIYVCnpmV3vWrj003a7XasvJS01Uej49dyM3NmTlrfIvQNj/MW+rk6GwwGL4Z2P3fFSqVCoTQ9JnfY5t42DiKCKHyijIu951TfdV9/ZrqqZlMJnVx+dDJwkyvpVKp9Hp9/G9xu/f8UvUBZeWl2OfPYv7z2WJfYHMtHyE0fdo8/waN/jx/KuHIPh6P17tXxOhRE7C/3Jwqr4V19MjlMmwVVP1Ncd78Tb31TcDW07tWQa3fqw+ES9zweHyFQl71FoVC7ihy4rA5VCoV+4Be365UVPutatiw8YIflun1+kePknfu2vLD/GmHD55iMpl4VEtaLBZLpVJVvcXUvuDx+Ewm85e4/VXvpVJraavyePyQkNCZ0+dXvZFT3Q/m4qVzer1+wfzl2Je1qKjwXQtECM3/YZl/g0ZVb3dxrqVfv9r1W/NTTIlmolK//nCE9g5Vv1R1XIJGU/3w3Ww2m06n9+s7sEf3r6vebu8gwrZEqn635XJZra9b9+Vj7cr+/Qf17z+ovLzs3J9JO3/dYm/v8M2AoaZwx2A/HIHADlsFVe9SvuM39ZZqV8H7fa/qzpwbU6Ye36ZNAtMzUk1bjzK5LCfnRUBAEJ1Ob9SwyaPHyaanPH3y0LRJZZKa+vjJk4cIIRqNFhraavSoCRKJuLy8zIylWgVPT2+pVJKXn4tdffQo2bRbNyAgSKPR6PV6Hx8/7B+TyXJyqmUOwmbNgvPyXnl4eJmeRaFQsP0Ub9FqNSwW2/SH8c/zb2cBtq79/RszGIyKinLTAu3shEKhfc1/GGpev++aZ5HH5VX9eVdUlJt6sho3apqa9litfh0f584lTZk2FutGrbpALpdXNR2yn2VW+0JUKrVx44CiogLTm3J396TR6XYCO28v36rb/jqdLjnlXg3v9L8uXy6X/3n+tE6nQwiJRI4Dvx0eGBhi6ql9/iJb8v+/N9gRAz7efv7+jWk02uMn//R+PnnykM/ne3p611DDu1bB+32v/sN7N9eCBHxBVlZ6Zla6RCLu02eAWq1avXbJq1cvnz3LWrZ8Po/H/7JrT4TQgAFDb968djhhb2FhwYPkuxs3r23evGXAm3Fz6/aN+QtnXL5yIS8/NzMrPTHxoJuru6ur5abWJYn27TqwWKxNm9fm5Lx49Ch5a9wGUzS0atm2caOmP61YmJx8r6Aw//yFM+O+H3zseELNC+zVs39lpXLV6ujMrPTc3Jzde3aMGvNNWtqTfz+yWUCwRCI+feZ4WVnpH8cS0tKf2Ns7ZGdnyOVyO4EdQujmzWsvXjzj8/k9e/aL/y3u4qVz+QV5D5LvzoqKrPVoz3etXxaLxWKxUh7ez8xKx35yVbm4uAmF9uf+TNLpdDK5LHbjatOmZc8e/XQ63fKfFjx+nHLt2l9xv8T6+jSgUqlVS0UINWnS7Nr1vyQSsVar3bd/17+7okwGfjv8ytWL+w/Ev3r1MjMr/acVC6dMHaNQKNzc3AMDQ/Yf2HXn7s3MrPS165YxGO8z8/K7lk+hUGI3rlq7bllmVnp+Qd75C2cyMlJDQ1/3pAgEdmvXLn3x4ll6Rmrc9p89Pb1DQkKFdsJuX/Xet3/XtWt/FRUVnj178tjxhP79Bpl6Tv/TKni/71XdmW1jqm/fgStW/jhl6pjF0Wvatvl4zarN23dsHDtuEI1GCwkOjVkXZ2/vgBD64vOv1GrV4YS9v+zYxOPxO4R/9v33U99a1NAho3U67bZtG0rLSng8fnBw85UrYv/dlrZ5IpHjooUrN29dP3bcIP8GjSZNnLVm3VImk4X9UVq1cuPWuA2LFkepVJVubh7Dho0dEDGk5gW6ubmvXxe3fXvslKljaDSan1/DZUvXV7uPOSzs02+/GRa3PXbL1vXt2obPjVp85Pd9Bw7+RqVSJ0+a3bZtGLanef26bZHjpwv4gu2/xJaVlYpEjmEffzpm9MSay6hh/Q4aOPLgod/+/vvq3j1v701nMplz5yzevGVdrz6fubi4jR0zsbikCGvCuLq6rVqxcdv2n2fOnmBnJ/zssy7fjZmE5csbpU6YsXrN4oGDewoEdt27ff1l15537vxdbYWfftL5h3lLDxyM3xW/DaswZl0ctntrwfzla9cunb9gOnbcTZcvutdxX3gdl79q5aYdOzbNmPm9RqNxc/MYNXL8V1/2wp7l5+vfrl34vB+mlpaVNGrUdHH0GuxDw3aQbYhdKRZXuDi7Dh0yZvCgke+3Ct7ve1V31U/ae/tsuUaFmn8mMtfLWNjFA/nNPxH6BdVpJ6XFnNye3zBU6NX0P1QlkUrY/9+o0Wg0ffp2HvfdlL5fw0k69c6i6Ci5XLZu7VaiC6ndqZ25Hfs5uflVMy+mbU78YhvkcvnQYX1atmg7fNh3FArlUMIeKpX66Sedia4LgPcEcUNefD5/1cpNv/yyccq0MVQKtWGjJmtWba62Z5dsHj1K/mHBtHfdu3fPsbocTWNF6tv7fW8QN6QW2Cw4Zn0c0VX8Z02aNNv+5s7UqkzHGdoMC7zfxdGrP3whhIO4AebHYrHc3TyIrsJy6tv7fW8kGl4LAGDbIG4AABYCcQMAsBCIGwCAhUDcAAAsBOIGAGAhEDcAAAuBuAEAWAjEDQDAQqo/qpjJphiQFQ/4wLNnUGmkq5/nwKDCUdzA1gmdGZR3NGOqv1ngwCh5WYlvUXjKSZWL3Eg30iibQy3Lr37ASgBsxvOHckf36n991ceNizfLekezqpTrnDxZfHvSNSTc/FjqSj3RVQCAI3GJxi+IS2dUHyzvbN14NmJf+b36AbFJ7vze/DZdHIiuohoNgvnqSv2ja+VEFwIAXi7sy2/f/Z0zN1Q/mh/myd+SzGR5846ODq5MGp3sncoqpV5aqrl+rPir4a4uPtWMJEYS5w8Usdh0n0C+yI1Vh4cDYAUq5TpJqfbKkcL+kz3tXd7Zj1FT3CCEnj9RJF8WFz5X0eik3rgSOjGk5Vq/QF7rLg4O7363JJFyRfz0ltSgQwrp2wOAA/PSGwxUKoVizfs9yE/kzpKUaPyDuW27OfLsaurEqCVuTNSVBvOVZ35GA2LzyN7+eovRgDRqUn+qNmD69OnDhw9v0aIF0YXYMqMRsbl1+vXVtT+VxbGyHzP5UajwqeJOb1TRmUb4nEkCVgMAwEIgboAtc3FxMeOcs+ADwZoAtqy4uNg0ey8gHMQNsGVeXl40Go3oKsBrEDfAluXm5ur1cCQ3WUDcAFsGrRtSgbgBtgxaN6QCcQNsGYfDoVjv2cY2B+IG2LLKyso6HjcPLADiBgBgIRA3wJZ5e3tDVzF5QNwAW/bq1SvoKiYPiBsAgIVA3ABb5uzsDOdMkQesCWDLSkpK4Jwp8oC4AQBYCMQNsGVcLhcO8yMPiBtgy5RKJRzmRx4QN8CWQdOGVCBugC2Dpg2pQNwAACwE4gbYMh6PB9tT5AFxA2yZQqGA7SnygLgBAFgIxA2wZTDxC6nAmgC2DCZ+IRWIGwCAhUDcAFsGMzGQCsQNsGUwEwOpQNwAACwE4gbYMjabDYf5kQfEDbBlKpUKDvMjD4gbYMugq5hUIG6ALYOuYlKBuAG2TCQSwVHF5AFrAtiy8vJyOKqYPCBugC2D1g2pwJoAtgxaN6QCcQNsGeyZIhWIG2DLYM8UqVDgIChge7p3744NPUGlUk3/d+zYMSYmhujS6jVo3QAb1Lx5c4QQ1kmM/e/h4TF27Fii66rvIG6ADRo6dKibm5vpqtFoDA0NDQoKIrQoAHEDbFFQUBDWwMG4u7sPHDiQ0IoAgrgBNmvIkCFYA8dgMISGhgYHBxNdEYC4ATYqMDAwNDQU67WBpg1JQNwAm/Xtt9+KRKKQkBBo2pAE7AgHxHvxVPEyXVWaq66U63Rao0pptiNldDodjUqjUM0zwpa9C6tSpuPwaXwHursvu1FzntCJYZYl1xMQN4AwZQXqexclGfekds4cgQufzqDSWTQGk06hk3f8PZ1ar9PodWq9UqySlymZLEpIB2HLTvZE12UdIG4AAeRi3aUjpcWv1C4NRXwnjvWO76mSa6SFcnGBPKyXY/DHdkSXQ3YQN8DSHt6QP7om4Tny7T34RNdiHlq1rjirgsk0fD3eg8EkuhoSg7gBFvV3UnnWY5X3R65EF2J+sjJlYWrpiIW+TDbsgakexA2wnAdXZGn3lO4BTkQXghetSleUVhIx1YPNhcSpBnwowELuXRSnP7DlrEEIMdh09yDX+MXPiS6EpCBugCXkpCuf3JK7NbHlrMHQGFTv5m4H1+USXQgZQdwA3BkMxgsHSrybu9XhsbaA58Cm89h3z1cQXQjpQNwA3P2dVC5w5Vvv3u734OTrcPNUmcEAHaNvgLgB+NKoDQ+viJ386t2BcO5NRFeOlhFdBblA3AB8pVwWOzYgb9akPL4wa2E7hUJs9iU7+goz78uM0MCpAuIG4CvjvkIg4hBdBTHYAubLNCXRVZAIxA3AkUKqU0h1HCGL6EKIwXPkZj5QEF0FidCJLgDYsvzsSpEXD7/l5+annfpzS25+ml6nbdywTe9u00UO7gih3Qd/oFBQ08YfX7qyWyIrcXHy7dtzlq93CEJIr9cdOxVz/+EZo8EQ2LRDI//W+JXHd+RK86D75h/QugE4klXo9Dq8dkhViAu3/RpJpVAnjN4yfvRmpVIaFz9Jq9MghGg0+vOXKTmvnkyL3B095wyXKzyUuAx71sUrv926+0fvbtOmR+5u4Bd6/vKvOJWHEKIzqcU5lfgt3+pA3AAcySU6GhOvWeX+vpOIKJQhA5a6uzby9gwcFBFdXpH36MlF7F6NprJ3t2ksJofJZLf86Kvi0hcajQohdC/ldHBgx7Ytezk5eoe17d+kYTucykMIUWlUCgVpVDCN52sQNwBHeh1icvDaYM959djHM5DDEWBXHezdRA6eeQUZ2FUnR28mk41d5nLsEELKSqlOpy0te+XtGWhaiI8XvtMzOHhw5BIdri9hRaDvBuDIoDdq1XhNYlmpUuQXps+J7mC6Ra/XSmWl2GU6/d/900aNphIhxKhyF4vFxak8jKRIBadrmkDcABwJHOilJXjFDZvNa+ATGtFnbtUbmcya4oPBZCOEKtVy0y2VlTKcysPmt9KoDFwB/Mpegw8C4IgvpBl0GpwW7usdfPdBkqPIi0Z7/TUuLnlpJ6jpLFAGnelg715QmGm6JSP7Nk7lYSONsvl4dV1ZI2jmARw5e7NVUrzipn3rvmq18mDikrz89JLSnD8v7Vy7adCrvCc1P6tFSNfHTy/fvPtHQWHW5ev78v/f14OHSqna2ZON3/KtDrRuAI6cPVkGnV6r0jHY5v+miRzcx4/eknRu0+Yd46hUmptLw1FD1mIH19SgS+exCqX45JlYg9HQrEl4j66Tdh+aZzDisvNIUaZsHo7jYUdWB0bzA/i6eKi4QsJw9K6Pw4anX3k5fL4vB7an/g82pgC+AtsLVJL6eN6QvEzp2ZALWVMVbEwBfLn5cuzsqZIihdC1+s2K9Mybew7Pr/YuHkeoqJRUe1f7Vl/3/GqyuYp8/jJ5596Z1d5lMOipFCqqbrCe1qHdv+5R/bMQQsVZ5X2+ry8jitURbEwB3ElKtQk/5zUK8672Xo1GJVeUv+su06F6b2GxeDyu0FwVarVqmbz6k5u0WjWNxqBSq9kOYDK5fF71Y2uI8+VMamX3URA3b4C4AZZw60x5fo7RwZu8A9+YV/aNV6MW+1LNNFmwzYC+G2AJ7b4S0YwaabG8Do+1es9v5/WZ4A5Z828QN8BCen/vrpUppMU2Pv5L3qPCzt86OXnU0yF+agZxAyyn/yQPeZFEnC8luhC8vLiT90kfkW8AvudhWS/ouwGWdm5fsUxKsfcU0hi2s5NYUqQoTC/tN9HT2QvaNe8EcQMI8PSW9EpiqchL4NzQwdonhFGUVxZnlzu6MXqOdqXSYXOhJhA3gDC3z1Zkpij0egrPkWvnzMXjRAecGPQGpVgtK1XKS5VOnszwniIXbzg3qnYQN4BgL1MVmcmK8iJd8Usli0tj8xlEV/RObD5DVqrSVOroLKqdiNmkBc//I56diLwFkw3EDSALo8GokOqVUr1WQ9LRNikUCodP5drRmGyqtW8DEgLiBgBgIdCzBQCwEIgbAICFQNwAACwE4gYAYCEQNwAAC4G4AQBYyP8AP/CuzJ0YkjMAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import Image, display\n",
     "display(Image(graph.get_graph().draw_mermaid_png()))"
@@ -237,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,98 +220,332 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "================================\u001b[1m Human Message \u001b[0m=================================\n",
-      "\n",
-      "what a blog about the types of agents\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "Tool Calls:\n",
-      "  retriever_tool (toolu_bdrk_01GfjWuQLebWppSaGgV5ma8M)\n",
-      " Call ID: toolu_bdrk_01GfjWuQLebWppSaGgV5ma8M\n",
-      "  Args:\n",
-      "    query: types of agents and their characteristics\n",
-      "QUERYING KB\n",
-      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: retriever_tool\n",
-      "\n",
-      "The search results do not provide specific information about different types of agents and their characteristics. The results primarily focus on memory systems for Large Language Model (LLM) agents and do not contain a comprehensive list or description of various agent types. However, the results do mention LLM agents, which are described as extending the capabilities of large language models by enabling interactive decision-making and executing complex workflows through structured interaction patterns. While not providing a full typology of agents, the results do discuss some characteristics of LLM agents, particularly in relation to memory systems. These agents require memory systems to leverage historical experiences effectively. The search results mention various approaches to memory management for LLM agents, including comprehensive interaction storage, cache-like architectures to prioritize recent information, and self-controlled memory frameworks. These memory systems aim to enhance the agents' ability to maintain long-term memory and handle diverse real-world tasks.\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "Tool Calls:\n",
-      "  blogger_tool (toolu_bdrk_013tbpEfYKEp6s27DozTN9ph)\n",
-      " Call ID: toolu_bdrk_013tbpEfYKEp6s27DozTN9ph\n",
-      "  Args:\n",
-      "    context: Title: Understanding Different Types of AI Agents: A Comprehensive Overview\n",
-      "\n",
-      "In the rapidly evolving landscape of artificial intelligence, AI agents have become increasingly sophisticated and diverse. Let's explore the various types of AI agents and their unique characteristics.\n",
-      "\n",
-      "1. LLM-based Agents\n",
-      "Large Language Model (LLM) based agents represent one of the most advanced forms of AI agents today. These agents extend the capabilities of traditional language models by:\n",
-      "- Enabling interactive decision-making\n",
-      "- Executing complex workflows through structured interaction patterns\n",
-      "- Utilizing sophisticated memory systems for improved performance\n",
-      "- Leveraging historical experiences for better outcomes\n",
-      "\n",
-      "2. Memory-Enhanced Agents\n",
-      "These specialized agents are designed with advanced memory management systems, featuring:\n",
-      "- Comprehensive interaction storage capabilities\n",
-      "- Cache-like architectures for prioritizing recent information\n",
-      "- Self-controlled memory frameworks\n",
-      "- Ability to maintain and utilize long-term memory effectively\n",
-      "\n",
-      "3. Task-Specific Agents\n",
-      "These agents are customized for particular functions and typically include:\n",
-      "- Specialized programming for specific domains\n",
-      "- Focused capability sets\n",
-      "- Optimized performance for their intended tasks\n",
-      "- Limited but highly efficient functionality\n",
-      "\n",
-      "4. Multi-Agent Systems\n",
-      "These complex systems involve multiple agents working together and feature:\n",
-      "- Collaborative problem-solving capabilities\n",
-      "- Distributed task management\n",
-      "- Inter-agent communication protocols\n",
-      "- Coordinated decision-making processes\n",
-      "\n",
-      "The Future of AI Agents\n",
-      "As AI technology continues to advance, we can expect to see:\n",
-      "- More sophisticated agent architectures\n",
-      "- Enhanced memory management systems\n",
-      "- Improved decision-making capabilities\n",
-      "- Better integration with real-world applications\n",
-      "\n",
-      "Each type of agent serves specific purposes and continues to evolve as technology progresses. The key to successful implementation lies in choosing the right type of agent for specific use cases while considering factors such as task complexity, required memory capabilities, and interaction patterns.\n",
-      "WRITING BLOG\n",
-      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: blogger_tool\n",
-      "\n",
-      "content=\"Title: The Four Key AI Agents Reshaping Our Digital Future\\n\\nIn the fascinating world of artificial intelligence, AI agents are becoming increasingly sophisticated, fundamentally changing how we interact with technology. From the cutting-edge LLM-based agents that harness the power of large language models to make complex decisions, to memory-enhanced agents that utilize advanced storage systems for improved learning, the landscape is diverse and rapidly evolving. Task-specific agents excel in focused domains with optimized performance, while multi-agent systems demonstrate the power of collaboration through coordinated problem-solving. As these technologies continue to advance, we're witnessing a transformation in how AI agents are integrated into real-world applications, promising even more sophisticated capabilities and broader implementation across various sectors.\" additional_kwargs={'usage': {'prompt_tokens': 419, 'completion_tokens': 157, 'total_tokens': 576}, 'stop_reason': 'end_turn', 'model_id': 'us.anthropic.claude-3-5-sonnet-20241022-v2:0'} response_metadata={'usage': {'prompt_tokens': 419, 'completion_tokens': 157, 'total_tokens': 576}, 'stop_reason': 'end_turn', 'model_id': 'us.anthropic.claude-3-5-sonnet-20241022-v2:0'} id='run-de5d6885-440e-4e47-9e01-0d749b7bbd27-0' usage_metadata={'input_tokens': 419, 'output_tokens': 157, 'total_tokens': 576}\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "\n",
-      "I've created a comprehensive blog post about different types of AI agents. The blog covers four main categories of agents: LLM-based Agents, Memory-Enhanced Agents, Task-Specific Agents, and Multi-Agent Systems. Each category is explained with its key characteristics and capabilities. Would you like me to translate this blog into any specific language? If so, I can use the translate tool to help with that.\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "\n",
-      "I've created a comprehensive blog post about different types of AI agents. The blog covers four main categories of agents: LLM-based Agents, Memory-Enhanced Agents, Task-Specific Agents, and Multi-Agent Systems. Each category is explained with its key characteristics and capabilities. Would you like me to translate this blog into any specific language? If so, I can use the translate tool to help with that.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "from langchain_core.messages import HumanMessage\n",
     "config = {\"configurable\": {\"thread_id\": \"42\"}}\n",
     "\n",
-    "inputs = {\"messages\": [(\"user\", \"what a blog about the types of agents\")]}\n",
+    "inputs = {\"messages\": [HumanMessage(\"what a blog about the types of agents\")]}\n",
     "print_stream(graph.stream(inputs, config, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = {\"messages\": [HumanMessage(\"Can you translate it to deutsch?\")]}\n",
+    "print_stream(graph.stream(inputs, config, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Build the agent (Custom with Post-processing Node) (Advanced)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from langchain_core.messages import ToolMessage, SystemMessage\n",
+    "from langchain_core.runnables import RunnableConfig\n",
+    "from typing import (\n",
+    "    Annotated,\n",
+    "    Sequence,\n",
+    "    TypedDict,\n",
+    "    Dict,\n",
+    "    Tuple\n",
+    ")\n",
+    "from langchain_core.messages import BaseMessage\n",
+    "from langgraph.graph.message import add_messages\n",
+    "\n",
+    "\n",
+    "class AgentState(TypedDict):\n",
+    "    \"\"\"The state of the agent.\"\"\"\n",
+    "    # add_messages is a reducer\n",
+    "    # See https://langchain-ai.github.io/langgraph/concepts/low_level/#reducers\n",
+    "    messages: Annotated[Sequence[BaseMessage], add_messages]\n",
+    "    formatted_blog: Dict\n",
+    "    \n",
+    "tools_by_name = {tool.name: tool for tool in tools}\n",
+    "\n",
+    "# Define our tool node\n",
+    "def tool_node(state: AgentState):\n",
+    "    outputs = []\n",
+    "    for tool_call in state[\"messages\"][-1].tool_calls:\n",
+    "        tool_result = tools_by_name[tool_call[\"name\"]].invoke(tool_call[\"args\"])\n",
+    "        outputs.append(\n",
+    "            ToolMessage(\n",
+    "                content=json.dumps(tool_result),\n",
+    "                name=tool_call[\"name\"],\n",
+    "                tool_call_id=tool_call[\"id\"],\n",
+    "            )\n",
+    "        )\n",
+    "    return {\"messages\": outputs}\n",
+    "\n",
+    "\n",
+    "# Define the node that calls the model\n",
+    "def call_model(\n",
+    "    state: AgentState,\n",
+    "    config: RunnableConfig,\n",
+    "):\n",
+    "    # this is similar to customizing the create_react_agent with 'prompt' parameter, but is more flexible\n",
+    "    system_prompt = SystemMessage(\n",
+    "        \"You are a helpful AI assistant who can write a blog using knowledge retreived and also translate it when required.\" \n",
+    "        \"\\n Please respond to the users query to the best of your ability using tools made available to you.\"\n",
+    "        \"\\n translate_tool should be called only to translate the overall blog and not the conversations. Once translate is called, that will be the last step for that converstaion.\"\n",
+    "    )\n",
+    "    llm_with_tools = llm.bind_tools(tools)\n",
+    "    response = llm_with_tools.invoke([system_prompt] + state[\"messages\"], config)\n",
+    "    # We return a list, because this will get added to the existing list\n",
+    "    return {\"messages\": [response]}\n",
+    "\n",
+    "\n",
+    "# Define the conditional edge that determines whether to continue or not\n",
+    "def should_continue(state: AgentState):\n",
+    "    messages = state[\"messages\"]\n",
+    "    last_message = messages[-1]\n",
+    "    # If there is no function call, then we finish\n",
+    "    if not last_message.tool_calls:\n",
+    "        return \"end\"\n",
+    "    # Otherwise if there is, we continue\n",
+    "    else:\n",
+    "        return \"continue\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import ToolMessage, HumanMessage, SystemMessage,AIMessage\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "class FormattedResponse(BaseModel):\n",
+    "    \"\"\"Respond to the user in this format.\"\"\"\n",
+    "    Blog_Title: str = Field(description=\"title of the blog\")\n",
+    "    Blog_Content: str = Field(description=\"content of the blog\")\n",
+    "    Blog_language: str = Field(description=\"language of the blog\")\n",
+    "\n",
+    "def formatter_node(state):\n",
+    "    \"\"\"\n",
+    "    Post-processing node that formats the final blog output using structured LLM parsing.\n",
+    "    Only uses tool outputs from blogger_tool or translate_tool after the most recent human message.\n",
+    "    \"\"\"\n",
+    "    print(\"FORMATTING BLOG WITH STRUCTURED PARSER\")\n",
+    "\n",
+    "    messages = state[\"messages\"]\n",
+    "\n",
+    "    # Step 1: Find the index of the most recent HumanMessage\n",
+    "    last_human_index = -1\n",
+    "    human_msg = None\n",
+    "    for i in reversed(range(len(messages))):\n",
+    "        if isinstance(messages[i], HumanMessage):\n",
+    "            last_human_index = i\n",
+    "            human_msg = messages[i]\n",
+    "            break\n",
+    "\n",
+    "    if last_human_index == -1:\n",
+    "        print(\"No recent HumanMessage found. Skipping formatting.\")\n",
+    "        return {}\n",
+    "\n",
+    "    # Step 2: Gather ToolMessages from blogger_tool or translate_tool after the last HumanMessage\n",
+    "    relevant_content = []\n",
+    "    for msg in messages[last_human_index + 1:]:\n",
+    "        if isinstance(msg, ToolMessage) and msg.name in [\"blogger_tool\", \"translate_tool\"]:\n",
+    "            relevant_content.append(msg.content)\n",
+    "\n",
+    "    if not relevant_content:\n",
+    "        error_msg = \"No recent blogger/translate tool outputs found.\"\n",
+    "        print(error_msg)\n",
+    "        return {\"formatted_blog\":{\"error\":error_msg}}\n",
+    "\n",
+    "    combined_blog_text = \"\\n\\n\".join(relevant_content)\n",
+    "\n",
+    "    # Step 3: Format with structured output\n",
+    "    format_prompt = SystemMessage(\n",
+    "        content=(\n",
+    "            \"You will be given a series of tool outputs from a blogging agent as input. The Content can be in any language; depending on whethere translation was performed.\"\n",
+    "            \"Extract or Derive and format it into a JSON object with the following fields:\\n\"\n",
+    "            \"\\t- Blog_Title: The title of the blog. Create a title if unable to extract\\n\"\n",
+    "            \"\\t- Blog_Content: The content in MD format; Add Headers, Subheaders, Highlighting, Bullets, Numbering wherever required. Use the final language in which blog was written when generating blog_content\\n\"\n",
+    "            \"\\t- Blog_language: The language used (detect it)\\n\\n\"\n",
+    "            \"Respond only with the Structured format.\\n\"\n",
+    "        )\n",
+    "    )\n",
+    "    structured_llm = llm.with_structured_output(FormattedResponse)\n",
+    "    final_prompt = [format_prompt, HumanMessage(content=f\"Here is the context of the blog for you to provide me with a structured output:\\n{combined_blog_text}\")]\n",
+    "    result = structured_llm.invoke(final_prompt)\n",
+    "    print(result)\n",
+    "    return {\n",
+    "        \"messages\":AIMessage(\"Formatting complete, graph state updated - `formatted_blog`\",metadata=result.model_dump()),\n",
+    "        \"formatted_blog\": result.model_dump()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.graph import StateGraph, END\n",
+    "\n",
+    "# Define a new graph\n",
+    "workflow = StateGraph(AgentState)\n",
+    "\n",
+    "# Define the two nodes we will cycle between\n",
+    "workflow.add_node(\"agent\", call_model)\n",
+    "workflow.add_node(\"tools\", tool_node)\n",
+    "# Define the additional node that will be used to format the work after agent finished interactions with tools\n",
+    "workflow.add_node(\"format_blog\",formatter_node)\n",
+    "# Set the entrypoint as `agent`\n",
+    "# This means that this node is the first one called\n",
+    "workflow.set_entry_point(\"agent\")\n",
+    "\n",
+    "# We now add a conditional edge\n",
+    "workflow.add_conditional_edges(\n",
+    "    # First, we define the start node. We use `agent`.\n",
+    "    # This means these are the edges taken after the `agent` node is called.\n",
+    "    \"agent\",\n",
+    "    # Next, we pass in the function that will determine which node is called next.\n",
+    "    should_continue,\n",
+    "    # Finally we pass in a mapping.\n",
+    "    # The keys are strings, and the values are other nodes.\n",
+    "    # END is a special node marking that the graph should finish.\n",
+    "    # What will happen is we will call `should_continue`, and then the output of that\n",
+    "    # will be matched against the keys in this mapping.\n",
+    "    # Based on which one it matches, that node will then be called.\n",
+    "    {\n",
+    "        # If `tools`, then we call the tool node.\n",
+    "        \"continue\": \"tools\",\n",
+    "        # Otherwise we finish. (Calling Format_blog is considered last step of agent)\n",
+    "        \"end\": \"format_blog\",\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# We now add a normal edge from `tools` to `agent`.\n",
+    "# This means that after `tools` is called, `agent` node is called next.\n",
+    "workflow.add_edge(\"tools\", \"agent\")\n",
+    "# We now add a normal edge from `format_blog` to `END`.\n",
+    "# This means that after `format_blog` is called, graph workflow is complete.\n",
+    "workflow.add_edge(\"format_blog\", END)\n",
+    "\n",
+    "# Now we can compile and visualize our graph\n",
+    "graph = workflow.compile(checkpointer=memory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "display(Image(graph.get_graph().draw_mermaid_png()))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_stream(stream):\n",
+    "    \"\"\"A utility to pretty print the stream.\"\"\"\n",
+    "    for s in stream:\n",
+    "        message = s[\"messages\"][-1]\n",
+    "        if isinstance(message, tuple):\n",
+    "            print(message)\n",
+    "        else:\n",
+    "            message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "config = {\"configurable\": {\"thread_id\": \"41\"}}\n",
+    "\n",
+    "inputs = {\"messages\": [HumanMessage(\"what a blog about the types of agents\")]}\n",
+    "print_stream(graph.stream(inputs, config, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "graph.get_state(config).values.get(\"formatted_blog\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "inputs = {\"messages\": [HumanMessage(\"translate it to french\")]}\n",
+    "print_stream(graph.stream(inputs, config, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph.get_state(config).values.get(\"formatted_blog\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "inputs = {\"messages\": [HumanMessage(\"traducir el texto al español\")]}\n",
+    "print_stream(graph.stream(inputs, config, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph.get_state(config).values.get(\"formatted_blog\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -358,9 +559,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This pull request introduces the following enhancements to Lab 6 (6.prebuilt_react.ipynb):​

1. Removal of formatted_response from the prebuilt element. The formatted_response component has been eliminated to streamline the prebuilt React agent's functionality. This simplification enhances clarity and maintainability.​
2. Addition of a subsection on creating a custom React agent with a custom graph using reducers. A new subsection has been added, providing detailed guidance on constructing a custom React agent.​
3. Adding clarity in prompts for better reasoning and returning string type responses from tool calls instead of ai message type.

This new section includes:​

1. An overview of the custom React agent's architecture.
2. Step-by-step instructions for implementing custom graphs with reducers.
4. Example code snippets to illustrate key concepts by implementing the react agent from core langchain/langgraph modules

These updates aim to enhance the instructional value of Lab 6 by offering users a clearer understanding of customizing React agents within the langgraph_bedrock framework especially for formatting and customizing the default graph with additional nodes

Graph of custom react agent with formatting node attached
![Image 4-2-25 at 4 42 PM](https://github.com/user-attachments/assets/ab7a3d6d-f277-4394-bbfb-7a3e66bb90c5)
